### PR TITLE
新增功能：监视客户端进度，ban掉吸血且一直汇报无进度的客户端IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,23 @@ aria2 自动 ban 掉迅雷等不受欢迎客户端的脚本（仅限 Linux）
 通过 aria2 RPC （就是API）自动查找不受欢迎的 peer 然后使用 iptables + ipset 来封禁其 IP （所以 Windows / macOS 不魔改是没法用的）  
 
 这是不修改 aria2 源码（其实就是自己太菜了 改不动 C++）而 ban 掉这些客户端的一个办法。
+## 客户端屏蔽规则
+### 关键字
+应该好理解吧，就是客户端名称符合关键字就ban
+### 监视进度
+- 初筛（也就是最长那行if）
+  - 名称符合config.noprogress_keywords
+  - 上传速度大于1KiB/s（太少就不管了吧，节约点性能，毕竟我写的应该一言难尽）
+  - 汇报进度为0（```aria2.getPeers```的```bitfield```全为0）
+    - TODO：不为0时也可以算下增幅够不够
+
+符合的再进行下列判断
+- 判断进度不对劲的规则
+  - 上传了超过5个块的量
+  - 进度为0（以后可以改成各种进度不对劲的都算）
+  - 持续超过10次扫描
+  
+> **_注：_** 此处使用扫描时的瞬时速度当作扫描间隔里的平均速度，统计对每个peer的上传量（因为没找到aria2c RPC怎么获取现成/精确的每个peer的上传量，transmission倒是有）
 ## 依赖
 `nodejs` `ipset` `iptables`  
 自行参考[Node.js 官方教程](https://github.com/nodesource/distributions/blob/master/README.md)  
@@ -51,40 +68,36 @@ aria2 自动 ban 掉迅雷等不受欢迎客户端的脚本（仅限 Linux）
     git pull # 更新
 ## 配置
 目前版本已经默认开箱即用了，欢迎报告 bug  
-abt 会读取本地的 `aria2.conf` 来找 aria2 RPC 端口以及 secret 之类的  
-默认读取的路径为 `$HOME/.aria2/aria2.conf` -> `/tmp/etc/aria2/aria2.conf.main` (OpenWRT)-> `/etc/aria2/aria2.conf` -> `./aria2.conf`  
+* 使用aria2的配置文件
+aria2b支持寄生配置。会读取aria2本体的配置文件来找 aria2 RPC 端口以及 secret 等各种参数。因此仅需一个配置文件即可对同时 aria2 和 aria2b 做修改。
+  * 默认读取的路径为 `$HOME/.aria2/aria2.conf` -> `/tmp/etc/aria2/aria2.conf.main` (OpenWRT)-> `/etc/aria2/aria2.conf` -> `./aria2.conf`  
 主机若为本地则默认关闭证书校验（自行 `update-ca-trust` 让本地系统信任之类的其实更好）  
-可以使用 -c 来指定 aria2 的配置文件
-
+  * 也可以使用 -c 来指定 aria2 的配置文件
+    ```
     aria2b -c <path>
-
-也可以手动使用 -u 与 -s 手动配置
-
+    ```
+* 使用命令行
+也可以在命令行中设置aria2b的各种参数。例如：
+    ```
     aria2b -u <url> -s <secret>
-
-以及支持寄生配置，仅需修改 aria2 本体配置文件即可对 aria2b 做修改  
-目前支持以下配置：  
-
-```
-ab-bt-ban-client-keywords=XL,SD,XF,QN,BD
-ab-bt-ban-timeout=86400
-```
-另外寄生配置不支持结尾带 # 注释
+    ```
 
 所有配置如下表所示：
-| 描述 | cli |  config  | 默认值 | 备注
+| 描述 | cli |  aria2 config 寄生配置  | 默认值 | 备注
 |-|-|-|-|-|
 | rpc url | -u --url | N/A | http://127.0.0.1:6800/jsonrpc 
 | rpc secret | -s --secret | ab-rpc-secret | N/A
 | ban 客户端关键字 | -b --block-keywords | ab-bt-ban-client-keywords | XL,SD,XF,QN,BD | 以,为分割符
 | 需监视进度的客户端关键字 | --noprogress-keywords | ab-bt-noprogress-keywords | XL,SD,XF,QN,BD,Unknown | 以,为分割符
-| 进度阈值 | --noprogress-piece| ab-bt-noprogress-piece | 5 | 单位：种子的片段数
+| 进度阈值 | --noprogress-piece| ab-bt-noprogress-piece | 5 | 单位：种子的分片数
 | 超过阈值等待次数 | --noprogress-wait | ab-bt-noprogress-wait | 10 |
 | IP 解除封禁时间 | --timeout | ab-bt-ban-timeout | 86400 | 以秒来计算
 | 关闭证书校验 | --rpc-no-verify | ab-rpc-no-verify| N/A | rpc 为本地时默认关闭证书校验 
 | 自定义信任ca证书 | --rpc-ca | ab-rpc-ca | N/A | 路径/base64两次编码
 | 自定义信任证书 | --rpc-cert | ab-rpc-cert | N/A | 路径/base64两次编码
 | 自定义信任私钥 | --rpc-key | ab-rpc-key | N/A | 路径/base64两次编码
+
+> **_注意：_** ⚠️寄生配置**不**支持结尾带 # 注释
 
 `--rpc-ca` `--rpc-cert` `--rpc-key` 需要同时配置，不然还是会不信任，这是 Node.js 的[设定](https://nodejs.org/api/tls.html)，这里推荐系统去手动信任 ca 证书来完成而不是这么麻烦（搜索关键词 `update-ca-trust`）  
 ## 守护
@@ -121,7 +134,7 @@ pm2 start --name 'aria2b' aria2b
 pm2 save
 pm2 startup
 ```
-# blocklist 参考 (block_keywords)
+# blocklist 参考 (--block-keywords)
 | 客户端 |  Peer名称 |
 |-|-|
 | 迅雷 | XL SD |

--- a/README.md
+++ b/README.md
@@ -77,6 +77,9 @@ ab-bt-ban-timeout=86400
 | rpc url | -u --url | N/A | http://127.0.0.1:6800/jsonrpc 
 | rpc secret | -s --secret | ab-rpc-secret | N/A
 | ban 客户端关键字 | -b --block-keywords | ab-bt-ban-client-keywords | XL,SD,XF,QN,BD | 以,为分割符
+| 需监视进度的客户端关键字 | --noprogress-keywords | ab-bt-noprogress-keywords | XL,SD,XF,QN,BD,Unknown | 以,为分割符
+| 进度阈值 | --noprogress-piece| ab-bt-noprogress-piece | 5 | 单位：种子的片段数
+| 超过阈值等待次数 | --noprogress-wait | ab-bt-noprogress-wait | 10 |
 | IP 解除封禁时间 | --timeout | ab-bt-ban-timeout | 86400 | 以秒来计算
 | 关闭证书校验 | --rpc-no-verify | ab-rpc-no-verify| N/A | rpc 为本地时默认关闭证书校验 
 | 自定义信任ca证书 | --rpc-ca | ab-rpc-ca | N/A | 路径/base64两次编码

--- a/app.js
+++ b/app.js
@@ -53,7 +53,12 @@ function decodeClient(str) {
 
 function countOnes(hexString) {
     // 将十六进制字符串转换为二进制字符串
-    const binaryString = BigInt(`0x${hexString}`).toString(2);
+    let binaryString
+    try{
+        binaryString = BigInt(`0x${hexString}`).toString(2)
+    } catch(e){
+        binaryString = "0"
+    }
     // 计算二进制字符串中1的个数
     let count = 0;
     for (const char of binaryString) {

--- a/app.js
+++ b/app.js
@@ -40,11 +40,16 @@ let cron_processing_flag = true
 let torrentInfo = {}    // [peerId] = [gid, numPieces, pieceLength]
 let peerUploaded = {}   // [peerId] = [uploaded, over 5 timeout]
 
-function countOnes(n) {
+
+function countOnes(hexString) {
+    // 将十六进制字符串转换为二进制字符串
+    const binaryString = BigInt(`0x${hexString}`).toString(2);
+    // 计算二进制字符串中1的个数
     let count = 0;
-    while (n !== 0) {
-        n = n & (n - 1);
+    for (const char of binaryString) {
+        if (char === '1') {
         count++;
+        }
     }
     return count;
 }
@@ -79,7 +84,7 @@ async function cron() {
                 await asyncForEach(d_peer.data.result[0][0], async peer => {
                     let c = get_peer_name(decodePercentEncodedString(peer.peerId))
                     let toBlock=0
-                    let bitprogress = countOnes(parseInt("0x"+peer.bitfield))
+                    let bitprogress = countOnes(peer.bitfield)
                     if (!blocked_ips.includes(peer.ip)) {
                         if (new RegExp('(' + config.block_keywords.join('|') + ')').test(c.origin)) toBlock = 1
                         else {
@@ -92,7 +97,7 @@ async function cron() {
                                     if(bitprogress == 0 && peer.downloadSpeed == 0){
                                         peerUploaded[[peer.peerId,1]] += 1
                                         if (peerUploaded[[peer.peerId,1]] > config.noprogress_wait) {
-                                            honsole.log(`往 ${peer.peerId} 传输了 ${uploadPiece} 个piece，但它声称进度 ${countOnes(parseInt("0x"+peer.bitfield))}/${torrentInfo[peer.peerId][1]} ，累犯 ${peerUploaded[[peer.peerId,1]]} 次，ban了`)
+                                            honsole.log(`往 ${peer.peerId} 传输了 ${uploadPiece} 个piece，但它声称进度 ${countOnes(peer.bitfield)}/${torrentInfo[peer.peerId][1]} ，累犯 ${peerUploaded[[peer.peerId,1]]} 次，ban了`)
                                             toBlock = 1
                                         }
                                     }

--- a/app.js
+++ b/app.js
@@ -182,9 +182,10 @@ https://github.com/makeding/aria2b`)
         if (cron_processing_flag) {
             cron()
         }
-    }, 5000) // 频率，自己改改，个人感觉不需要太频繁，反正最多被偷一点点流量。
+    }, scan_interval)
     cron()
 }
+const scan_interval = 5000 // 频率，自己改改，个人感觉不需要太频繁，反正最多被偷一点点流量。单位毫秒
 initial()
 /**
  * 从 aria2 配置文件读取配置

--- a/app.js
+++ b/app.js
@@ -53,14 +53,16 @@ async function cron() {
                 })
                 await asyncForEach(d_peer.data.result[0][0], async peer => {
                     let c = get_peer_name(decodePercentEncodedString(peer.peerId))
+                    let toBlock=0
                     if (!blocked_ips.includes(peer.ip)) {
-                        if (config.block_keywords.includes('Unknown') && c.client == 'unknown') {
+                        if (new RegExp('(' + config.block_keywords.join('|') + ')').test(c.origin)) toBlock = 1
+                        if ((config.block_keywords.includes('Unknown') || toBlock == 1) && c.client == 'unknown') {
                             await block_ip(peer.ip, {
                                 origin: 'Unknown',
                                 client: '',
                                 version: ''
                             })
-                        } else if (new RegExp('(' + config.block_keywords.join('|') + ')').test(c.origin)) {
+                        } else if (toBlock == 1) {
                             await block_ip(peer.ip, c)
                         }
                     }

--- a/app.js
+++ b/app.js
@@ -135,6 +135,11 @@ ${prefix}-u,--url <rpc url> (default: http://127.0.0.1:6800/jsonrpc)
 ${prefix}-s, --secret <secret>
 ${prefix}--timeout <seconds> (default: 86400)
 ${prefix}--block_keywords <string>
+${prefix}--noprogress-keywords <string>
+${prefix}--noprogress-piece <int> (default: 5)
+${prefix}--noprogress-wait <int> (default: 10)
+    Monitors the progress of peers matching the keywords in <noprogress-keywords>. If the upload to the peer exceeds <noprogress-piece> pieces and the peer has not reported progress for <noprogress-wait> times, the peer will be blocked.
+
 ${prefix}--flush flush ipset bt_blacklist(6)
 
 -----Advanced Options-----
@@ -201,6 +206,9 @@ https://github.com/makeding/aria2b`)
     if (argv.u || argv.url) config.rpc_url = argv.u || argv['rpc-url']
     if (argv.s || argv.secret) config.secret = argv.s || argv.secret
     if (argv.b || argv['block-keywords']) config.block_keywords = (argv.b || argv['block-keywords']).replace(/ /g, '').split(',')
+    if (argv['noprogress-keywords']) config.noprogress_keywords = (argv['noprogress-keywords']).replace(/ /g, '').split(',')
+    if (argv['noprogress-piece']) config.noprogress_piece = argv['noprogress-piece']
+    if (argv['noprogress-wait']) config.noprogress_wait = argv['noprogress-wait']
     if (argv['rpc-ca']) config.rpc_options.ca = argv['rpc-ca']
     if (argv['rpc-cert']) config.rpc_options.cert = argv['rpc-cert']
     if (argv['rpc-key']) config.rpc_options.key = argv['rpc-key']
@@ -267,6 +275,15 @@ async function load_config_from_aria2_file(path) {
             }
             if (x.startsWith('ab-bt-ban-client-keywords')) {
                 config.block_keywords = value.split(',')
+            }
+            if (x.startsWith('ab-bt-noprogress-keywords')) {
+                config.noprogress_keywords = value.split(',')
+            }
+            if (x.startsWith('ab-bt-noprogress-piece')) {
+                config.noprogress_piece = value
+            }
+            if (x.startsWith('ab-bt-noprogress-wait')) {
+                config.noprogress_wait = value
             }
             // 信任自签 CA 证书
             if (x.startsWith('ab-rpc-ca')) {

--- a/app.js
+++ b/app.js
@@ -40,6 +40,16 @@ let cron_processing_flag = true
 let torrentInfo = {}    // [peerId] = [gid, numPieces, pieceLength]
 let peerUploaded = {}   // [peerId] = [uploaded, over 5 timeout]
 
+function decodeClient(str) {
+    return str.replace(/%[0-9A-Fa-f]{2}/g, match => {
+        const charCode = parseInt(match.slice(1), 16);
+        // Decode only if the character is printable ASCII
+        if (charCode >= 32 && charCode <= 126) {
+            return String.fromCharCode(charCode);
+        }
+        return match; // Preserve the original encoding for unprintable characters
+    });
+}
 
 function countOnes(hexString) {
     // 将十六进制字符串转换为二进制字符串
@@ -97,7 +107,7 @@ async function cron() {
                                     if(bitprogress == 0 && peer.downloadSpeed == 0){
                                         peerUploaded[[peer.peerId,1]] += 1
                                         if (peerUploaded[[peer.peerId,1]] > config.noprogress_wait) {
-                                            honsole.log(`往 ${peer.peerId} 传输了 ${uploadPiece} 个piece，但它声称进度 ${countOnes(peer.bitfield)}/${torrentInfo[peer.peerId][1]} ，累犯 ${peerUploaded[[peer.peerId,1]]} 次，ban了`)
+                                            honsole.log(`往 ${decodeClient(peer.peerId).substring(0, 16).padEnd(16, ' ')}（${peer.ip}）\t传输了 ${String(uploadPiece).substring(0,8)}\t个piece，但它声称进度 ${countOnes(peer.bitfield)}/${torrentInfo[peer.peerId][1]} ，累犯 ${peerUploaded[[peer.peerId,1]]} 次，ban了`)
                                             toBlock = 1
                                         }
                                     }


### PR DESCRIPTION
## 背景
- 最近发现有许多客户端（大多是随机id）吃大量上传，但进度一直汇报为0。
本来一般吸血吧，但也有据说是PCDN为了平衡上下行比例恶意刷流量的（来源：[差评君的微博](https://weibo.com/5734325998/Oqgeha9bp ） 。
- 我发现我居然能吸到迅雷的血
![天呐噜，迅雷居然有上传](https://github.com/user-attachments/assets/72a3da10-7921-4411-9448-1c62924ba3ef)
所以还是不要一刀切地按名字ban啰

## 逻辑
### 初筛（也就是最长那行if）
- 名称符合config.noprogress_keywords
- 上传速度大于1KiB/s（太少就不管了吧，节约点性能，毕竟我写的应该一言难尽）
- 汇报进度为0（```aria2.getPeers```的```bitfield```全为0）
  - TODO：不为0时也可以算下增幅够不够

符合的再进行下列判断
### 判断规则
注：使用扫描时的瞬时速度当作扫描间隔里的平均速度，统计对每个peer的上传量（因为没找到aria2c RPC怎么获取现成/精确的每个peer的上传量，transmission倒是有）

- 上传了超过5个块的量
- 进度为0（以后可以改成各种进度不对劲的都算）
- 持续超过10次扫描

就ban IP

## 注意事项
- 每个种子的每个peer客户端的上传量都存在全局变量里的，应该不会爆吧
- 第一次写JS && 第一次提正经PR，请勿轻易合并或盲目运行